### PR TITLE
#12: [display real data] show a loader (closes #12)

### DIFF
--- a/src/components/LoadingSpinner/LoadingSpinner.ts
+++ b/src/components/LoadingSpinner/LoadingSpinner.ts
@@ -1,0 +1,3 @@
+import LoadingSpinner from '@buildo/bento/components/LoadingSpinner';
+
+export default LoadingSpinner;

--- a/src/components/LoadingSpinner/LoadingSpinner.ts
+++ b/src/components/LoadingSpinner/LoadingSpinner.ts
@@ -1,4 +1,4 @@
 import LoadingSpinner from '@buildo/bento/components/LoadingSpinner';
-import '@buildo/bento/components/loadingspinner.scss';
+import '@buildo/bento/components/loadingSpinner.scss';
 
 export default LoadingSpinner;

--- a/src/components/LoadingSpinner/LoadingSpinner.ts
+++ b/src/components/LoadingSpinner/LoadingSpinner.ts
@@ -1,3 +1,4 @@
 import LoadingSpinner from '@buildo/bento/components/LoadingSpinner';
+import '@buildo/bento/components/loadingspinner.scss';
 
 export default LoadingSpinner;

--- a/src/components/LoadingSpinner/index.ts
+++ b/src/components/LoadingSpinner/index.ts
@@ -1,0 +1,2 @@
+import LoadingSpinner from './LoadingSpinner';
+export default LoadingSpinner;

--- a/src/components/ResultsPanel/ResultsPanel.tsx
+++ b/src/components/ResultsPanel/ResultsPanel.tsx
@@ -3,6 +3,7 @@ import ScrollView from 'ScrollView';
 import View from 'View';
 import ResultsRow from 'ResultsRow';
 import Panel from 'Panel';
+import LoadingSpinner from 'LoadingSpinner';
 import { SearchResult } from 'model';
 import { FormattedMessage } from 'react-intl';
 
@@ -44,9 +45,15 @@ class ResultsPanel extends React.PureComponent<Props> {
     return null;
   };
   render() {
-    const { searchGithubRepo } = this.props;
+    const {
+      searchGithubRepo,
+      readyState: { searchGithubRepo: { loading } }
+    } = this.props;
     const placeholderMessage = this.getPlaceholderMessage();
 
+    if (loading) {
+      return <LoadingSpinner />;
+    }
     return (
       <ScrollView className="results-panel">
         <View column grow hAlignContent="center">

--- a/src/components/ResultsPanel/ResultsPanel.tsx
+++ b/src/components/ResultsPanel/ResultsPanel.tsx
@@ -52,7 +52,11 @@ class ResultsPanel extends React.PureComponent<Props> {
     const placeholderMessage = this.getPlaceholderMessage();
 
     if (loading) {
-      return <LoadingSpinner />;
+      return (
+        <View grow className="results-panel results-panel-loading">
+          <LoadingSpinner />
+        </View>
+      );
     }
     return (
       <ScrollView className="results-panel">

--- a/src/components/ResultsPanel/resultsPanel.scss
+++ b/src/components/ResultsPanel/resultsPanel.scss
@@ -4,4 +4,9 @@
   border: solid 1px $debug-color;
   margin-top: 20px;
   max-width: 1000px;
+
+  &-loading {
+    position: relative;
+    border: none;
+  }
 }


### PR DESCRIPTION
Closes #12

## Test Plan
Usando la proprietà `loading` di una Query Avenger definisco quando visualizzare il componente LoadingSpinner del framework Buildo-React-Components. 

![image](https://user-images.githubusercontent.com/22859283/37288476-aadac606-2607-11e8-8d98-77681615bac5.png)


Soltanto gli ultimi 3 commit corrispondono a questa PR. Ho dovuto fare questo branch non dal master, ma da #13  
### tests performed
> A Test Plan is used to show what you tested to make sure your code works fine. You should write here all that you did to test, and provide some results of your testing.

> These results can be screenshots, query results, or even just pointers to unit tests that successfully passed.}

### tests not performed (domain coverage)
> At times not everything can be tested, and writing what hasn't been tested is just as important as writing what has been tested.

> An example of partial test is a field displaying 4 possible values. If 3 values are tested, with screenshots, and 1 is not, then it should be mentioned here.}
