### PR TITLE
#15: [display real data] Show repo details (closes #15)

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,6 +13,7 @@
     "classnames": "^2.2.5",
     "es6-promise": "^4.2.2",
     "lodash": "^4.17.4",
+    "query-string": "^5.1.0",
     "react": "^16.2.0",
     "react-dom": "^16.2.0",
     "react-input-children": "^4.0.1"

--- a/src/API/API.ts
+++ b/src/API/API.ts
@@ -1,9 +1,15 @@
 const API_URL = 'https://api.github.com/';
 const SEARCH_REPO_ENDPOINT = 'search/repositories';
+const GET_REPO_ENDPOINT = 'repositories';
 import { SearchResult } from 'model';
 
 export const searchGithubRepo = (query: string) => {
   return fetch(API_URL + SEARCH_REPO_ENDPOINT + `?q=${query}`).then(res =>
     res.json()
   ) as Promise<Array<SearchResult>>;
+};
+export const searchGithubRepoByID = (ID: number | string) => {
+  return fetch(API_URL + GET_REPO_ENDPOINT + `/${ID}`).then(res =>
+    res.json()
+  ) as Promise<SearchResult>;
 };

--- a/src/API/API.ts
+++ b/src/API/API.ts
@@ -8,7 +8,7 @@ export const searchGithubRepo = (query: string) => {
     res.json()
   ) as Promise<Array<SearchResult>>;
 };
-export const searchGithubRepoByID = (ID: number | string) => {
+export const searchGithubRepoByID = (ID: number) => {
   return fetch(API_URL + GET_REPO_ENDPOINT + `/${ID}`).then(res =>
     res.json()
   ) as Promise<SearchResult>;

--- a/src/components/App/App.tsx
+++ b/src/components/App/App.tsx
@@ -2,22 +2,55 @@ import * as React from 'react';
 import View from 'View';
 import NavBar from 'NavBar';
 import ResultsPanel from 'ResultsPanel';
+import ResultDetails from 'ResultDetails';
+
 import './app.scss';
+import { declareQueries, declareCommands } from '@buildo/bento/data';
+import { CurrentView } from 'model';
 
 type State = {
   query: string;
 };
-export default class App extends React.Component<{}, State> {
-  state = {
+type Props = {
+  currentView: CurrentView;
+  doUpdateLocation(location: {
+    pathname: string | undefined;
+    search: string | undefined;
+  }): void;
+};
+
+class App extends React.Component<Props, State> {
+  state: State = {
     query: ''
   };
   onSearchSubmit = (query: string) => {
     this.setState({ query });
   };
+
+  onDialogClose = () => {
+    this.props.doUpdateLocation({ pathname: '', search: 'r' });
+  };
+
+  renderModal = () => {
+    const { currentView } = this.props;
+    if (currentView && currentView.payload.repo) {
+      return (
+        <ResultDetails
+          query={this.state.query}
+          ID={currentView.payload.repo}
+          onDialogClose={this.onDialogClose}
+        />
+      );
+    }
+    return null;
+  };
+
   render() {
-    const { state: { query }, onSearchSubmit } = this;
+    const { state, onSearchSubmit, renderModal } = this;
+
     return (
       <View column className="app">
+        {renderModal()}
         <View
           basis={50}
           className="app-header"
@@ -28,9 +61,14 @@ export default class App extends React.Component<{}, State> {
         </View>
 
         <View column className="app-content" grow hAlignContent="center">
-          <ResultsPanel query={query} />
+          <ResultsPanel query={state.query} />
         </View>
       </View>
     );
   }
 }
+
+const queries = declareQueries(['currentView']);
+const command = declareCommands(['doUpdateLocation']);
+
+export default command(queries(App));

--- a/src/components/App/App.tsx
+++ b/src/components/App/App.tsx
@@ -28,16 +28,16 @@ class App extends React.Component<Props, State> {
   };
 
   onDialogClose = () => {
-    this.props.doUpdateLocation({ pathname: '', search: 'r' });
+    this.props.doUpdateLocation({ pathname: '/', search: '' });
   };
 
   renderModal = () => {
     const { currentView } = this.props;
-    if (currentView && currentView.payload.repo) {
+    if (currentView && currentView.view === 'details') {
       return (
         <ResultDetails
           query={this.state.query}
-          ID={currentView.payload.repo}
+          ID={currentView.repo}
           onDialogClose={this.onDialogClose}
         />
       );

--- a/src/components/Modal/Modal.ts
+++ b/src/components/Modal/Modal.ts
@@ -1,0 +1,4 @@
+import * as Modal from 'buildo-react-components/lib/Modal';
+import '@buildo/bento/components/modal.scss';
+
+export default Modal;

--- a/src/components/Modal/Modal.ts
+++ b/src/components/Modal/Modal.ts
@@ -1,4 +1,4 @@
-import * as Modal from 'buildo-react-components/lib/Modal';
+import Modal, { modalWithContext } from 'buildo-react-components/lib/Modal';
 import '@buildo/bento/components/modal.scss';
-
 export default Modal;
+export { modalWithContext };

--- a/src/components/Modal/index.ts
+++ b/src/components/Modal/index.ts
@@ -1,0 +1,2 @@
+import Modal from './Modal';
+export default Modal;

--- a/src/components/Modal/index.ts
+++ b/src/components/Modal/index.ts
@@ -1,2 +1,3 @@
-import Modal from './Modal';
+import Modal, { modalWithContext } from './Modal';
 export default Modal;
+export { modalWithContext };

--- a/src/components/ResultDetails/ResultDetails.tsx
+++ b/src/components/ResultDetails/ResultDetails.tsx
@@ -5,14 +5,13 @@ import View from 'View';
 import LoadingSpinner from 'LoadingSpinner';
 import { declareQueries } from '@buildo/bento/data';
 import { SearchResult } from 'Model';
-import { FormattedMessage } from 'react-intl';
+import { FormattedMessage, intlShape } from 'react-intl';
 import * as PropTypes from 'prop-types';
 
 import './resultDetails.scss';
-const ReactINTLContextType = PropTypes.object.isRequired;
 
 const ResultsDetailsModal = modalWithContext({
-  intl: ReactINTLContextType
+  intl: intlShape
 });
 type Props = {
   onDialogClose(): void;

--- a/src/components/ResultDetails/ResultDetails.tsx
+++ b/src/components/ResultDetails/ResultDetails.tsx
@@ -1,0 +1,115 @@
+import * as React from 'react';
+import Modal from 'Modal';
+
+import View from 'View';
+import LoadingSpinner from 'LoadingSpinner';
+import { declareQueries } from '@buildo/bento/data';
+import { SearchResult } from 'Model';
+import { FormattedMessage } from 'react-intl';
+import * as PropTypes from 'prop-types';
+
+import './resultDetails.scss';
+const FooType = PropTypes.object.isRequired;
+
+const ResultsDetailsModal = Modal.modalWithContext({ intl: FooType });
+type Props = {
+  onDialogClose(): void;
+} & (
+  | {
+      readyState: {
+        searchGithubRepoByID: {
+          loading: false;
+        };
+      };
+      searchGithubRepoByID: SearchResult;
+    }
+  | {
+      readyState: {
+        searchGithubRepoByID: {
+          loading: true;
+        };
+      };
+      searchGithubRepoByID: undefined;
+    });
+type State = {};
+
+class ResultDetails extends React.PureComponent<Props, State> {
+  render() {
+    const { onDialogClose, searchGithubRepoByID, readyState } = this.props;
+    if (readyState.searchGithubRepoByID.loading)
+      return (
+        <div className="result-details-loading">
+          <LoadingSpinner />
+        </div>
+      );
+    const {
+      description,
+      name,
+      html_url,
+      stargazers_count,
+      stargazers_url,
+      forks_count,
+      forks_url,
+      license,
+      owner
+    } = searchGithubRepoByID as SearchResult;
+    return (
+      <ResultsDetailsModal
+        transitionEnterTimeout={500}
+        transitionLeaveTimeout={0}
+        onDismiss={onDialogClose}
+        className="result-details"
+      >
+        <View column grow className="result-details-content">
+          <View vAlignContent="center">
+            <View grow column style={{ justifyContent: 'space-between' }}>
+              <a href={html_url}>
+                <div className="repo-name">{name}</div>
+              </a>
+              <div className="repo-owner">{owner.login}</div>
+            </View>
+            <a href={html_url} target="_blank">
+              <img
+                className="repo-owner-image"
+                src={owner.avatar_url}
+                alt="avatar"
+              />
+            </a>
+          </View>
+          <div className="repo-description">{description}</div>
+
+          <View grow className="repo-action">
+            <a href={stargazers_url} target="_blank">
+              <div>
+                <FormattedMessage
+                  id="ResultsDetails.star"
+                  values={{ stars: stargazers_count }}
+                />
+              </div>
+            </a>
+            <a href={forks_url} target="_blank">
+              <FormattedMessage
+                id="ResultsDetails.fork"
+                values={{ fork: forks_count }}
+              />
+            </a>
+            {license && (
+              <a href={license.url} target="_blank">
+                <FormattedMessage
+                  id="ResultsDetails.license"
+                  values={{ license: license.name }}
+                />
+              </a>
+            )}
+          </View>
+        </View>
+      </ResultsDetailsModal>
+    );
+  }
+}
+const queries = declareQueries(['searchGithubRepoByID']);
+export default (queries(ResultDetails) as any) as React.ComponentType<{
+  ID: number;
+  query: string;
+  onDialogClose(): void;
+}>;

--- a/src/components/ResultDetails/ResultDetails.tsx
+++ b/src/components/ResultDetails/ResultDetails.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import Modal from 'Modal';
+import { modalWithContext } from 'Modal';
 
 import View from 'View';
 import LoadingSpinner from 'LoadingSpinner';
@@ -9,9 +9,11 @@ import { FormattedMessage } from 'react-intl';
 import * as PropTypes from 'prop-types';
 
 import './resultDetails.scss';
-const FooType = PropTypes.object.isRequired;
+const ReactINTLContextType = PropTypes.object.isRequired;
 
-const ResultsDetailsModal = Modal.modalWithContext({ intl: FooType });
+const ResultsDetailsModal = modalWithContext({
+  intl: ReactINTLContextType
+});
 type Props = {
   onDialogClose(): void;
 } & (
@@ -42,6 +44,7 @@ class ResultDetails extends React.PureComponent<Props, State> {
           <LoadingSpinner />
         </div>
       );
+
     const {
       description,
       name,
@@ -53,6 +56,7 @@ class ResultDetails extends React.PureComponent<Props, State> {
       license,
       owner
     } = searchGithubRepoByID as SearchResult;
+
     return (
       <ResultsDetailsModal
         transitionEnterTimeout={500}

--- a/src/components/ResultDetails/index.ts
+++ b/src/components/ResultDetails/index.ts
@@ -1,0 +1,2 @@
+import ResultDetails from './ResultDetails';
+export default ResultDetails;

--- a/src/components/ResultDetails/resultDetails.scss
+++ b/src/components/ResultDetails/resultDetails.scss
@@ -1,0 +1,61 @@
+@import '~theme/variables.scss';
+
+.result-details {
+  .modal-body {
+    padding: 20px !important;
+  }
+
+  &-content {
+    width: 700px;
+
+    a {
+      color: inherit;
+      text-decoration: none;
+      transition: all 100ms cubic-bezier(.4, 0, .2, 1);
+      font-weight: $bold;
+    }
+
+    .repo- {
+      &name {
+        font-weight: $bold;
+        font-size: 22px;
+      }
+
+      &owner {
+        color: $coolGrey;
+
+        &-image {
+          width: 80px;
+          height: auto;
+        }
+      }
+
+      &description {
+        margin-top: .4em;
+        color: $coolBlack;
+        font-size: 16px;
+      }
+
+      &action {
+        justify-content: space-between;
+        margin-top: 1.5em;
+
+        a {
+          color: $coolGrey;
+
+          &:hover {
+            color: $coolBlack;
+          }
+        }
+      }
+    }
+
+    &-loading {
+      position: absolute;
+      top: 0;
+      right: 0;
+      width: 100%;
+      height: 100%;
+    }
+  }
+}

--- a/src/components/ResultsPanel/ResultsPanel.tsx
+++ b/src/components/ResultsPanel/ResultsPanel.tsx
@@ -66,7 +66,7 @@ class ResultsPanel extends React.PureComponent<Props> {
           ) : (
             searchGithubRepo &&
             searchGithubRepo.items.map(result => (
-              <ResultsRow key={result.id} {...result} />
+              <ResultsRow key={result.id} result={result} />
             ))
           )}
         </View>

--- a/src/components/ResultsRow/ResultsRow.tsx
+++ b/src/components/ResultsRow/ResultsRow.tsx
@@ -5,8 +5,16 @@ import Button from 'Button';
 import { FormattedMessage } from 'react-intl';
 
 import './resultsRow.scss';
+import { declareCommands } from '@buildo/bento/data';
 
-export default class ResultsRow extends React.PureComponent<SearchResult> {
+type Props = {
+  result: SearchResult;
+  doUpdateLocation(location: {
+    pathname: string | undefined;
+    search: string | undefined;
+  }): void;
+};
+class ResultsRow extends React.PureComponent<Props> {
   static defaultProps = {
     repoName: '',
     repoDescription: '',
@@ -14,10 +22,13 @@ export default class ResultsRow extends React.PureComponent<SearchResult> {
   };
 
   onSeeMoreClick = (): void => {
-    window.open(this.props.html_url, '_blank');
+    this.props.doUpdateLocation({
+      pathname: `/?repo=${this.props.result.id}`,
+      search: ''
+    });
   };
   render() {
-    const { name, description, html_url } = this.props;
+    const { result: { name, description, html_url } } = this.props;
 
     return (
       <View className="results-row" vAlignContent="center" width="100%">
@@ -37,3 +48,6 @@ export default class ResultsRow extends React.PureComponent<SearchResult> {
     );
   }
 }
+
+const commands = declareCommands(['doUpdateLocation']);
+export default commands(ResultsRow);

--- a/src/components/ResultsRow/ResultsRow.tsx
+++ b/src/components/ResultsRow/ResultsRow.tsx
@@ -23,7 +23,7 @@ class ResultsRow extends React.PureComponent<Props> {
 
   onSeeMoreClick = (): void => {
     this.props.doUpdateLocation({
-      pathname: `/?repo=${this.props.result.id}`,
+      pathname: `/details?repo=${this.props.result.id}`,
       search: ''
     });
   };

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -7,6 +7,9 @@
     "ResultsPanel.noQuerySearched":
       "Search a repo in the top bar to see the results!",
     "ResultsPanel.noResultsAvailable":
-      "Sorry, no results for your stupid query!"
+      "Sorry, no results for your stupid query!",
+    "ResultsDetails.star": "Stars: {stars}",
+    "ResultsDetails.fork": "Fork: {fork}",
+    "ResultsDetails.license": "License type: {license}"
   }
 }

--- a/src/locales/it.json
+++ b/src/locales/it.json
@@ -7,6 +7,9 @@
     "ResultsPanel.noQuerySearched":
       "Cerca un repo nella barra in alto per vedere i risultati!",
     "ResultsPanel.noResultsAvailable":
-      "Mi dispiace, ma la tua stupida ricerca non ha prodotto risultati!"
+      "Mi dispiace, ma la tua stupida ricerca non ha prodotto risultati!",
+    "ResultsDetails.star": "Stelle: {stars}",
+    "ResultsDetails.fork": "Fork: {fork}",
+    "ResultsDetails.license": "Tipo di licenza: {license}"
   }
 }

--- a/src/model/index.ts
+++ b/src/model/index.ts
@@ -22,22 +22,46 @@ in the example app created by default:
 */
 
 import { HistoryLocation } from '@buildo/bento/data';
-
+const qs = require('query-string');
 export { HistoryLocation };
+export type CurrentView = {
+  view: string;
+  payload: {
+    repo?: number;
+  };
+};
 
-export type CurrentView = 'home';
+interface License {
+  name: string;
+  url: string;
+}
+interface Owner {
+  login: string;
+  avatar_url: string;
+}
 export interface SearchResult {
   id: number;
   name: string;
   full_name: string;
   html_url: string;
   description: string;
+  topics: Array<string>;
+  created_at: string;
+  stargazers_count: number;
+  stargazers_url: string;
+  forks_count: string;
+  forks_url: string;
+  license: License;
+  owner: Owner;
 }
 export function locationToView(location: HistoryLocation): CurrentView {
+  const Location: CurrentView = { view: '', payload: {} };
   switch (location.pathname) {
     default:
-      return 'home';
+      Location.view = 'home';
   }
+  Location.payload = qs.parse(location.search);
+  return Location;
 }
 
 export function viewToLocation(view: CurrentView): HistoryLocation {

--- a/src/model/index.ts
+++ b/src/model/index.ts
@@ -24,12 +24,15 @@ in the example app created by default:
 import { HistoryLocation } from '@buildo/bento/data';
 const qs = require('query-string');
 export { HistoryLocation };
-export type CurrentView = {
-  view: string;
-  payload: {
-    repo?: number;
-  };
-};
+
+export type CurrentView =
+  | {
+      view: 'home';
+    }
+  | {
+      view: 'details';
+      repo: number;
+    };
 
 interface License {
   name: string;
@@ -39,7 +42,7 @@ interface Owner {
   login: string;
   avatar_url: string;
 }
-export interface SearchResult {
+export type SearchResult = {
   id: number;
   name: string;
   full_name: string;
@@ -53,15 +56,18 @@ export interface SearchResult {
   forks_url: string;
   license: License;
   owner: Owner;
-}
+};
 export function locationToView(location: HistoryLocation): CurrentView {
-  const Location: CurrentView = { view: '', payload: {} };
   switch (location.pathname) {
+    case '/details':
+      const search = qs.parse(location.search);
+      if (search.repo) {
+        return { view: 'details', repo: parseInt(search.repo) };
+      }
+
     default:
-      Location.view = 'home';
+      return { view: 'home' };
   }
-  Location.payload = qs.parse(location.search);
-  return Location;
 }
 
 export function viewToLocation(view: CurrentView): HistoryLocation {

--- a/src/queries/queries.js
+++ b/src/queries/queries.js
@@ -26,7 +26,7 @@ export const currentView = Query({
   fetch: ({ location }) => Promise.resolve(locationToView(location))
 });
 
-export const searchGithubRepoQuery = Query({
+export const searchGithubRepo = Query({
   id: 'searchGithubRepo',
   cacheStrategy: available,
 
@@ -40,5 +40,29 @@ export const searchGithubRepoQuery = Query({
     }
 
     return Promise.resolve({ error: 'noQuery' });
+  }
+});
+
+export const searchGithubRepoByID = Query({
+  id: 'searchGithubRepoByID',
+  cacheStrategy: available,
+  dependencies: {
+    results: {
+      query: searchGithubRepo
+    }
+  },
+  params: {
+    results: t.any,
+    query: t.string,
+    ID: t.union([t.number, t.string])
+  },
+
+  fetch: ({ results, ID }) => {
+    const item = results.items && results.items.filter(e => e.id === ID);
+    if (item && item.length) {
+      return Promise.resolve(item[0]);
+    } else {
+      return API.searchGithubRepoByID(ID);
+    }
   }
 });


### PR DESCRIPTION
Closes #15

## Test Plan
Ho modificato il Model per il CurrentView, trasformandolo in oggetto, contenente la path, ed i payload: sarebbero i parametri in query string. Permettendomi di leggerli dentro `App`, ed in base al parametro `repo` decidere se visualizzare un modal con maggiori informazioni rispetto a quel repo. 
Ho implementato una nuova richiesta API, che viene chiamata soltanto nel caso in cui non trova i risultati dalla query precedente. (Ditemi se ha senso questo passo.)
### tests performed
> A Test Plan is used to show what you tested to make sure your code works fine. You should write here all that you did to test, and provide some results of your testing.

> These results can be screenshots, query results, or even just pointers to unit tests that successfully passed.}

### tests not performed (domain coverage)
> At times not everything can be tested, and writing what hasn't been tested is just as important as writing what has been tested.

> An example of partial test is a field displaying 4 possible values. If 3 values are tested, with screenshots, and 1 is not, then it should be mentioned here.}
